### PR TITLE
[Task-2] added CloudFront and S3 static website links to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+CloudFront URL - http://d3ewwnk5pnu18r.cloudfront.net/
+S3 static website URL - http://serving-sp-app-rs-school-v1.s3-website.eu-north-1.amazonaws.com
+
 # React-shop-cloudfront
 
 This is frontend starter project for nodejs-aws mentoring program. It uses the following technologies:


### PR DESCRIPTION
Implementation details:
- Configured S3 static website, which is not accessible directly by this link and returns 403 - http://serving-sp-app-rs-school-v1.s3-website.eu-north-1.amazonaws.com
- Configured CloudFront accessing the Shop app from the S3 static website - https://d3ewwnk5pnu18r.cloudfront.net